### PR TITLE
dont use blob.bytes() method

### DIFF
--- a/src/hooks/useFlashblocks.ts
+++ b/src/hooks/useFlashblocks.ts
@@ -120,7 +120,8 @@ export const useFlashblocks = (): State => {
                 newFlashBlock = JSON.parse(textData) as Flashblock;
             } else {
                 try {
-                    const u8Data = await event.data.bytes()
+                    const arrayBuffer = await event.data.arrayBuffer()
+                    const u8Data = new Uint8Array(arrayBuffer)
                     const decompressedData = Buffer.from(brotli.decompress(u8Data)).toString("utf-8")
                     newFlashBlock = JSON.parse(decompressedData) as Flashblock;
                 } catch (decompressError) {


### PR DESCRIPTION
`Blob.bytes()` is not supported by chrome's javascript runtime

this uses arrayBuffer instead which is much more widely supported